### PR TITLE
(fix) bug installing wine32

### DIFF
--- a/states/common/wine-install.sls
+++ b/states/common/wine-install.sls
@@ -20,7 +20,6 @@ install_wine_stack:
     - pkgs:
         - wine
         - wine64
-        - wine32
         - libwine
         - fonts-wine
         - xvfb


### PR DESCRIPTION
Installing wine32 package results in error. Removing from state as it's ultimately unused for 64 bit use-cases.