### PR TITLE
(fix) added state requirement for steamcmd-install

### DIFF
--- a/states/apps/v_rising_server/install.sls
+++ b/states/apps/v_rising_server/install.sls
@@ -21,4 +21,5 @@ install_vrising:
         +quit
     - runas: {{ user }}
     - require:
+      - sls: common.steamcmd-install
       - file: /opt/game_servers/vrising_server/config_data


### PR DESCRIPTION
Addressing issue where state attempts to install v rising server with steamcmd before steamcmd state has ran which resulted in the state predictably failing.

![image](https://github.com/user-attachments/assets/8e3d5f71-63a4-469e-a9ca-da2ba67ed7c8)
