### PR TITLE
(fix) adding state for steam_server_manager

### DIFF
--- a/states/top.sls
+++ b/states/top.sls
@@ -13,4 +13,4 @@ base:
     - common.wine-install
     - common.xdg-runtime
     - common.user-create
-    - users
+    - users.steam_server_manager


### PR DESCRIPTION
Specifies which user to create on system